### PR TITLE
Add ICLR 2025 version DOI to citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,7 +13,7 @@ keywords:
   - CV
   - biology
   - images
-#doi:
+doi: 10.5281/zenodo.19830736
 license: MIT
 message: "If you find this software helpful in your research, please cite both the software and our paper."
 repository-code: "https://github.com/Imageomics/HComPNet"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # HComP-Net: Hierarchy aligned Commonality through Prototypical Networks [ICLR'25]
+
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19830736.svg)](https://doi.org/10.5281/zenodo.19830736)
+
 This repository presents the PyTorch code for **HComP-Net** (**H**ierarchy aligned **Com**monality through **P**rototypical **Net**works) 
 
 [Paper](https://arxiv.org/abs/2409.02335) | [Project Page](https://imageomics.github.io/HComPNet/)


### PR DESCRIPTION
Also added the DOI badge to the README:
<img width="1011" height="292" alt="Screenshot 2026-04-30 at 2 51 44 PM" src="https://github.com/user-attachments/assets/a7799077-02fc-4653-b13e-7ab172af5232" />

It didn't align well with the paper + project page line, since the badge kind of floats.